### PR TITLE
Debuff statuses should refer to "Debuff name", not "Buff name".

### DIFF
--- a/Statuses/Auras.lua
+++ b/Statuses/Auras.lua
@@ -741,7 +741,7 @@ function GridStatusAuras:OptionsForStatus(status, isBuff)
 					width = "double",
 					type = "select",
 					values = {
-						["name"] = L["Buff name"],
+						["name"] = L["Debuff name"],
 						["duration"] = L["Time left"],
 						["count"] = L["Stack count"],
 					},


### PR DESCRIPTION
In GridStatusAuras, statuses for debuffs that had advanced options enabled would list the three options for the status text to be "buff name", "time left", or "stack count".  Fix this to properly say "debuff name" for debuffs while still saying "buff name" for buffs.