### PR TITLE
Bump TOC interface to 80100 for BfA 8.1.

### DIFF
--- a/Grid.toc
+++ b/Grid.toc
@@ -1,4 +1,4 @@
-## Interface: 80000
+## Interface: 80100
 ## Version: @project-version@
 
 ## Title: Grid


### PR DESCRIPTION
I've tested on BfA 8.1 and it is safe to bump the TOC interface version to 80100 for compatibility with BfA 8.1.