### PR TITLE
Backdrop changes for Shadowlands (9.0)

### DIFF
--- a/Indicators/Border.lua
+++ b/Indicators/Border.lua
@@ -22,7 +22,8 @@ local BACKDROP = {
 GridFrame:RegisterIndicator("border", L["Border"],
 	-- New
 	function(frame)
-		frame:SetBackdrop(BACKDROP)
+		frame.backdropInfo = BACKDROP
+		frame:ApplyBackdrop()
 		return {}
 	end,
 
@@ -40,7 +41,8 @@ GridFrame:RegisterIndicator("border", L["Border"],
 		BACKDROP.insets.top = size
 		BACKDROP.insets.bottom = size
 
-		frame:SetBackdrop(BACKDROP)
+		frame.backdropInfo = BACKDROP
+		frame:ApplyBackdrop()
 		frame:SetBackdropColor(0, 0, 0, 1)
 		frame:SetBackdropBorderColor(r, g, b, a)
 	end,

--- a/Indicators/Corner.lua
+++ b/Indicators/Corner.lua
@@ -28,8 +28,9 @@ local anchor = {
 }
 
 local function New(frame)
-	local square = CreateFrame("Frame", nil, frame)
-	square:SetBackdrop(BACKDROP)
+	local square = CreateFrame("Frame", nil, frame, "BackdropTemplate")
+	square.backdropInfo = BACKDROP
+	square:ApplyBackdrop()
 	square:SetBackdropBorderColor(0, 0, 0, 1)
 	return square
 end

--- a/Indicators/Icon.lua
+++ b/Indicators/Icon.lua
@@ -22,9 +22,10 @@ local BACKDROP = {
 GridFrame:RegisterIndicator("icon", L["Center Icon"],
 	-- New
 	function(frame)
-		local icon = CreateFrame("Frame", nil, frame)
+		local icon = CreateFrame("Frame", nil, frame, "BackdropTemplate")
 		icon:SetPoint("CENTER")
-		icon:SetBackdrop(BACKDROP)
+		icon.backdropInfo = BACKDROP
+		icon:ApplyBackdrop()
 
 		local texture = icon:CreateTexture(nil, "ARTWORK")
 		texture:SetPoint("BOTTOMLEFT", 2, 2)
@@ -75,7 +76,8 @@ GridFrame:RegisterIndicator("icon", L["Center Icon"],
 		BACKDROP.insets.top = iconBorderSize
 		BACKDROP.insets.bottom = iconBorderSize
 
-		self:SetBackdrop(BACKDROP)
+		self.backdropInfo = BACKDROP
+		self:ApplyBackdrop()
 		self:SetBackdropBorderColor(r, g, b, a)
 
 		self.texture:SetPoint("BOTTOMLEFT", iconBorderSize, iconBorderSize)

--- a/Layout.lua
+++ b/Layout.lua
@@ -839,14 +839,15 @@ function GridLayout:CreateFrames()
 	f:SetScript("OnHide", GridLayout_OnMouseUp)
 
 	-- create backdrop
-	f.backdrop = CreateFrame("Frame", "$parentBackdrop", f)
+	f.backdrop = CreateFrame("Frame", "$parentBackdrop", f, "BackdropTemplate")
 	f.backdrop:SetPoint("BOTTOMLEFT", -4, -4)
 	f.backdrop:SetPoint("TOPRIGHT", 4, 4)
-	f.backdrop:SetBackdrop({
+	f.backdrop.backdropInfo = {
 		bgFile = "Interface\\ChatFrame\\ChatFrameBackground", tile = false, tileSize = 16,
 		edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border", edgeSize = 16,
 		insets = {left = 4, right = 4, top = 4, bottom = 4},
-	})
+	}
+	f.backdrop:ApplyBackdrop()
 
 	f:SetFrameLevel(f.backdrop:GetFrameLevel() + 2)
 
@@ -1206,7 +1207,8 @@ function GridLayout:UpdateColor()
 	backdrop.insets.right = settings.borderInset
 	backdrop.insets.top =  settings.borderInset
 	backdrop.insets.bottom = settings.borderInset
-	self.frame.backdrop:SetBackdrop(backdrop)
+	self.frame.backdrop.backdropInfo = backdrop
+	self.frame.backdrop:ApplyBackdrop()
 
 	self.frame.backdrop:SetBackdropBorderColor(settings.borderColor.r, settings.borderColor.g, settings.borderColor.b, settings.borderColor.a)
 	self.frame.backdrop:SetBackdropColor(settings.backgroundColor.r, settings.backgroundColor.g, settings.backgroundColor.b, settings.backgroundColor.a)


### PR DESCRIPTION
Default backdrop has been removed from all frames by default. The following steps need to be taken:
- use `BackdropTemplate` on frame creation where needed
- assign `frame.backdropInfo`
- call `frame:ApplyBackdrop()`

I have already made most changes, however, I could not figure out where the frames used in the Border.lua are being created, so `ApplyBackdrop()` causes an error as the `BackdropTemplate` is not set.

Also, this would need to be made compatible to live, if it was to be released before the prepatch.